### PR TITLE
Clean up styling with smoother page transitions

### DIFF
--- a/modern.css
+++ b/modern.css
@@ -1,3 +1,7 @@
+html {
+  overflow-y: scroll;
+}
+
 body {
   color: #2f3536;
   font-family: "georgia", "bitstream vera serif", serif;

--- a/modern.js
+++ b/modern.js
@@ -2,16 +2,16 @@ $(function() {
     function hide_content() {
       $("#content")
         .children("h2")
-        .hide()
+        .fadeOut()
         .next("div")
-        .hide();
+        .fadeOut();
     }
 
     function show_content(name) {
       $('#' + name)
-        .show()
+        .fadeIn()
         .next("div")
-        .show();
+        .fadeIn()
     }
 
     function show_only(name) {
@@ -49,7 +49,7 @@ $(function() {
         .click(function(e) {
             e.preventDefault();
 
-            $('#share').toggle();
+            $('#share').slideToggle();
         });
 
 


### PR DESCRIPTION
This adds an explicit overflow-y to stop the shifting of content when
going from pages with no scrollbar and pages that have them. This also
changes page hide() to fade() for a smoother transition. Lastly uses
slideToggle() for the share list.
