### PR TITLE
Remove unneeded XML-isms

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE HTML>
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html lang="en">
 <head>
-  <meta charset="UTF-8" />
+  <meta charset="UTF-8">
   <title>C* Music Player</title>
-  <meta name="Author" content="Timo Hirvonen"/>
-  <meta name="Description" content="Small, fast and powerful console music player"/>
-  <meta name="Keywords" content="cmus, console, curses, music, player, linux, unix, bsd, ogg, mp3, wav, flac, streaming"/>
-  <link rel="stylesheet" type="text/css" href="reset-min.css" />
-  <link rel="stylesheet" type="text/css" href="fonts-min.css" />
-  <link rel="stylesheet" type="text/css" href="modern.css" />
-  <link rel="alternate" type="application/atom+xml"  href="https://github.com/cmus/cmus/commits/master.atom" title="cmus project updates" />
+  <meta name="Author" content="Timo Hirvonen">
+  <meta name="Description" content="Small, fast and powerful console music player">
+  <meta name="Keywords" content="cmus, console, curses, music, player, linux, unix, bsd, ogg, mp3, wav, flac, streaming">
+  <link rel="stylesheet" href="reset-min.css">
+  <link rel="stylesheet" href="fonts-min.css">
+  <link rel="stylesheet" href="modern.css">
+  <link rel="alternate" type="application/atom+xml"  href="https://github.com/cmus/cmus/commits/master.atom" title="cmus project updates">
 
-  <script type="text/javascript">
+  <script>
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-34510696-1']);
     _gaq.push(['_trackPageview']);
@@ -219,7 +219,7 @@ make install</code></pre>
     </div>
   </div>
 
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
-  <script type="text/javascript" src="modern.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+  <script src="modern.js"></script>
 </body>
 </html>


### PR DESCRIPTION
&lt;link&gt; tags assume text/css if 'type' isn't specified:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style

&lt;script&gt; tags are assumed to be javascript if no 'type' is specified:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script

Self-closing tags in html don't need the trailing slash.

The doctype says this is HTML, so we don't need to add XML attributes to
the &lt;html&gt; tag.
