### PR TITLE
Add version 2.10.0 to download section

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,9 @@
     <div class="chapter">
       <h3>Stable Releases</h3>
       <ul>
+	<li><a href="https://github.com/cmus/cmus/archive/refs/tags/v2.10.0.tar.gz">cmus-2.10.0.tar.gz</a>, released 05.07.2022<br />
+    A lot of minor improvements and fixes compared to 2.9.1.
+    See <a href="https://github.com/cmus/cmus/releases/tag/v2.10.0">release notes</a> for a more complete list of changes.</li>
         <li><a href="https://github.com/cmus/cmus/archive/v2.9.1.tar.gz">cmus-2.9.1.tar.gz</a>, released 22.01.2021<br/>
     A lot of minor improvements and fixes compared to 2.8.0.
     See <a href="https://github.com/cmus/cmus/releases/tag/v2.9.1">release notes</a> for a more complete list of changes.</li>


### PR DESCRIPTION
Better to keep the last version released on the download section of the page, even if it has been quite a while since the version was released.