### PR TITLE
Add note about cmus on fedora via RPMFusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
       installation is straightforward, e.g.:
       <ul>
         <li><b>Debian/Ubuntu Linux</b>: <code>sudo apt-get install cmus</code></li>
+        <li><b>Fedora/RHEL Linux</b>: <code>sudo dnf install cmus</code> (requires <a href="https://rpmfusion.org/Configuration#Command_Line_Setup_using_rpm">enabling RPMFusion repos</a>)</li>
         <li><b>Arch Linux</b>: <code>sudo pacman -S cmus</code></li>
         <li><b>OS X</b>: <code>brew install cmus</code></li>
       </ul>


### PR DESCRIPTION
I just noticed cmus was in RPMFusion & that I didn't have to compile from source to get cmus working in a Fedora distrobox. This PR adds that information to the Documentation page of the website.